### PR TITLE
feat: configure TypeScript path aliases

### DIFF
--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -48,7 +48,7 @@
   - Add a `.gitkeep` or `index.ts` to each folder
   - **Deliverable**: Organized folder structure
 
-- [ ] **Task 1.3.2**: Configure path aliases
+- [x] **Task 1.3.2**: Configure path aliases
   - Update `tsconfig.json` to add path aliases (`@/components/*`, `@/lib/*`, etc.)
   - Verify imports work with aliases
   - **Deliverable**: Working path aliases

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,8 @@
+import { cn } from "@/lib/utils";
+
 export default function Home() {
   return (
-    <main className="flex min-h-screen flex-col items-center justify-center">
+    <main className={cn("flex min-h-screen flex-col items-center justify-center")}>
       <h1 className="text-4xl font-bold">Explain RFC</h1>
       <p className="mt-4 text-lg text-gray-600 dark:text-gray-400">
         Interactive RFC Learning Platform

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,7 +19,14 @@
       }
     ],
     "paths": {
-      "@/*": ["./src/*"]
+      "@/*": ["./src/*"],
+      "@/components/*": ["./src/components/*"],
+      "@/lib/*": ["./src/lib/*"],
+      "@/hooks/*": ["./src/hooks/*"],
+      "@/stores/*": ["./src/stores/*"],
+      "@/types/*": ["./src/types/*"],
+      "@/data/*": ["./src/data/*"],
+      "@/styles/*": ["./src/styles/*"]
     }
   },
   "include": [


### PR DESCRIPTION
- Added path aliases for @/components/*, @/lib/*, @/hooks/*
- Added path aliases for @/stores/*, @/types/*, @/data/*, @/styles/*
- Verified imports work with aliases in page.tsx
- Updated page.tsx to use cn() utility via @/lib/utils

Signed-off-by: avish.j@protonmail.com