### PR TITLE
fix: update base url for custom domain

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -7,12 +7,10 @@ import path from 'path';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
-const isProd = process.env.NODE_ENV === 'production';
-
 // https://astro.build/config
 export default defineConfig({
-  site: 'https://avishj.github.io',
-  base: isProd ? '/ExplainRFC/' : '/',
+  site: 'https://explainrfc.avishj.dev',
+  base: '/',
   integrations: [react()],
   vite: {
     plugins: [tailwindcss()],


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Updated Astro config to use the custom domain https://explainrfc.avishj.dev and set base to '/' in all environments. This fixes asset paths and canonical URLs after moving off the GitHub Pages subpath.

<sup>Written for commit 7e6e3e2a2b58099d3745dd1a216a71a2394e6f69. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated site domain to `https://explainrfc.avishj.dev`
  * Simplified base path configuration to use a consistent root path across environments

<!-- end of auto-generated comment: release notes by coderabbit.ai -->